### PR TITLE
HYDRAN-XYZ Exclude attachment endpoints from Logbook payload logging

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -210,6 +210,15 @@ server:
 # Logbook
 #----------------------------------------
 logbook:
+  # Exclude the attachment endpoints from payload logging. Their bodies are large
+  # base64 blobs (whole-file downloads/uploads). Logging them forces Logbook to
+  # buffer the body and JsonPath-parse it in full before the '$..file' redaction
+  # can run - which trips Jackson's 20M-char StreamReadConstraints limit and
+  # spikes the heap (contributing to OOM restarts). These bodies carry no useful
+  # log value, so we skip them entirely. Metadata for other endpoints is
+  # unaffected, and errands that *embed* attachments are still redacted below.
+  excluded:
+    paths: '**/attachments,**/attachments/**'
   body-filters:
     json-path:
       - key: '$..file'


### PR DESCRIPTION
## What
Adds the attachment endpoints to `logbook.excluded.paths` so Logbook skips payload logging for them:

```yaml
logbook:
  excluded:
    paths: '**/attachments,**/attachments/**'
```

Covers `AttachmentResource` (`…/errands/{id}/attachments` + `…/attachments/{id}`) and the message/conversation attachment binary GETs and attachment history (all match `**/attachments/**`).

## Why
Attachment endpoints return/accept whole-file **base64 bodies (~20 MB)**. To apply the existing `$..file → [base64]` redaction, dept44's `BodyFilterProvider` has to `JsonPath.parse()` the **entire** body first. On a 20 MB payload that:

1. trips Jackson's 20 M-char `StreamReadConstraints` limit → recurring `WARN Unable to log ... StreamConstraintsException` (seen in prod on errand 4423 attachments), and
2. allocates the full string + a 2–3× parse tree → heap spike, contributing to **OOM pod restarts** (SBA `OFFLINE`/`UP` flaps).

Excluding these paths stops Logbook from buffering/parsing those bodies at all. The bodies are opaque base64 with no log value.

## Scope / impact
- Logging-only change; **no HTTP behavior change**.
- Excluded paths log nothing (incl. metadata) — acceptable, since the bodies are unreadable base64.
- Errands that *embed* attachments (e.g. `GET /errands/{id}` with `decisions[].attachments[].file`) are on non-excluded paths and **still redacted** by the existing `$..file`/`$..content` filters.
- Other endpoints unaffected.

## Notes
- Config-only (`application.yml`). Verified YAML binds to `logbook.excluded.paths`; no other repo profile overrides it.
- Does not by itself *prove* OOM was the crash cause — still worth confirming the flapping pod's `Terminated` reason (`OOMKilled`/137). This removes a real heap-spike contributor + the WARN regardless.
- Longer-term root-cause fix belongs in dept44 (`BodyFilterProvider` should skip parsing bodies over a size threshold, preserving metadata logging for all services).